### PR TITLE
Feature/improve template engine

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,10 @@
 # Email         : P.Zarrad@outlook.de
 #==================================================================
 
+# ---- START: Constants used by PSH
+# All constants that not belong to plugins should be listed below and not
+# in sourced scripts, to have a central overview of them.
+
 # Dependencies that need to be installed with root privileges trhough apt-get
 readonly DEPENDENCIES=(
     "zsh"
@@ -40,6 +44,7 @@ readonly COLOR_YELLOW="\e[33m"
 readonly ERROR_PREFIX="${COLOR_RED}ERROR${COLOR_RESET}"
 readonly SUCCESS_PREFIX="${COLOR_GREEN}SUCCESS${COLOR_RESET}"
 readonly WARNING_PREFIX="${COLOR_YELLOW}WARNING${COLOR_RESET}"
+# ---- END: Constants used by PSH
 
 # Print an error message
 print_error() {

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck source=/dev/null
 
 #==================================================================
 # Script Name   : psh-installer
@@ -285,6 +284,7 @@ do
         then
             echo ""
             echo "Running plugin: ${plugin}"
+            # shellcheck source=/dev/null
             if source "$pluginFile"
                 then
                     print_success "Successfully executed plugin ${plugin}"

--- a/install.sh
+++ b/install.sh
@@ -224,56 +224,10 @@ echo ""
 
 echo "Preparing ${HOME}/.zshrc..."
 
-# Include templates into the new .zshrc
-include_templates() {
-    templateType="$1"
-    echo "# User defined templates: $templateType" >> "${HOME}/.zshrc"
-    templateFiles=()
-    while IFS='' read -r line; do templateFiles+=("$line"); done < <(ls -1 templates)
-    for templateFile in "${templateFiles[@]}"
-    do
-        templateFile="templates/${templateFile}"
-        if read -r templateHeader < "$templateFile"
-            then
-                if [ "$templateHeader" = "${TEMPLATE_DIRECTIVE}${templateType}" ]
-                        then
-                            echo "Applying template file ${templateFile}"
-                            if tail -n +2 "$templateFile" >> "${HOME}/.zshrc"
-                                then
-                                    print_success "Applied template file ${templateFile}!"
-                                else
-                                    print_error "Failed to apply template file ${templateFile}!"
-                                    exit 1
-                            fi
-                    fi
-                else
-                    print_error "Failed to read teamplate file ${templateFile}!"
-            fi
-    done
-}
-
-# Print warnings about template files that do not contain the #TEMPLATE=XXX header
-print_template_warnings() {
-    templateFiles=()
-    while IFS='' read -r line; do templateFiles+=("$line"); done < <(ls -1 templates)
-    if [ "${#templateFiles[@]}" -ge 1 ]
-        then
-            for templateFile in "${templateFiles[@]}"
-            do
-                templateFile="templates/${templateFile}"
-                if read -r templateHeader < "$templateFile"
-                    then
-                        if ! grep -q "$TEMPLATE_DIRECTIVE" <<< "$templateHeader"
-                            then
-                                print_warning "Not applied template due to missing template directive: ${templateFile}!"
-
-                        fi
-                    else
-                        print_error "Failed to read teamplate file ${templateFile}!"
-                fi
-            done
-    fi
-}
+# Load template engine
+echo ""
+source "lib/template_engine.sh"
+echo ""
 
 # Now reset ~/.zshrc, as we build our own only using antigen
 # to load things
@@ -328,9 +282,9 @@ do
             echo "Running plugin: ${plugin}"
             if source "$pluginFile"
                 then
-                    print_success "Run plugin ${plugin}"
+                    print_success "Successfully executed plugin ${plugin}"
                 else
-                    print_warning "Failed to run plugin ${plugin}!"
+                    print_warning "Failed to execute plugin ${plugin}!"
             fi
         else
             print_warning "Plugin ${plugin} has no plugin.sh, skipping!"
@@ -359,8 +313,8 @@ print_template_warnings
 # Ask user if he wants to set zsh as default shell
 echo ""
 echo ""
-echo "zsh has been installed and is now usable."
-echo "But it is currently not configured as your default shell."
+echo "zsh has been installed and is configured!"
+echo "It is currently not configured as your default shell."
 echo -e "${COLOR_CYAN}NOTE${COLOR_RESET} Only set for your current user account!"
 read -r -p "Do you want to set zsh as your default shell? (y/n): " confirmDefaultShell
 if [ "$confirmDefaultShell" = "y" ] || [ "$confirmDefaultShell" = "yes" ];

--- a/lib/template_engine.sh
+++ b/lib/template_engine.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+#==================================================================
+# Script Name   : psh-template-engine
+# Description	: Template engine of psh.
+# Args          : -
+# Author       	: Pascal Zarrad
+# Email         : P.Zarrad@outlook.de
+#==================================================================
+
+# Store the paths of our different template types in the arrays
+# to reduce I/O operations in comparison to v1 of the engine.
+templates_start=()
+templates_between_antigen_and_oh_my_zsh=()
+templates_between_oh_my_zsh_and_plugins=()
+templates_after_plugins_before_antigen_apply=()
+templates_end=()
+# Load our templates
+echo "Searching for templates..."
+templateFiles=()
+while IFS='' read -r line; do templateFiles+=("$line"); done < <(ls -1 templates)
+for templateFile in "${templateFiles[@]}"
+do
+    if [ -s "templates/$templateFile" ]; then
+        if read -r templateHeader < "templates/$templateFile"
+            then
+                case $templateHeader in
+                    "${TEMPLATE_DIRECTIVE}$TEMPLATE_START")
+                        templates_start=("${templates_start[@]}" "$templateFile")
+                        ;;
+                    "${TEMPLATE_DIRECTIVE}$TEMPLATE_BETWEEN_ANTIGEN_AND_OH_MY_ZSH")
+                        templates_between_antigen_and_oh_my_zsh=("${templates_between_antigen_and_oh_my_zsh[@]}" "$templateFile")
+                        ;;
+                    "${TEMPLATE_DIRECTIVE}$TEMPLATE_BETWEEN_OH_MY_ZSH_AND_PLUGINS")
+                        templates_between_oh_my_zsh_and_plugins=("${templates_between_oh_my_zsh_and_plugins[@]}" "$templateFile")
+                        ;;
+                    "${TEMPLATE_DIRECTIVE}$TEMPLATE_AFTER_PLUGINS_BEFORE_ANTIGEN_APPLY")
+                        templates_after_plugins_before_antigen_apply=("${templates_after_plugins_before_antigen_apply[@]}" "$templateFile")
+                        ;;
+                    "${TEMPLATE_DIRECTIVE}$TEMPLATE_END")
+                        templates_end=("${templates_end[@]}" "$templateFile")
+                        ;;
+                    *)
+                        templates_invalid=("${templates_invalid[@]}" "$templateFile")
+                        ;;
+                esac
+            else
+                    print_error "Failed to read teamplate file ${templateFile}!"
+        fi
+    fi
+done
+print_success "Completed template search!"
+
+# Include templates into the new .zshrc
+include_templates() {
+    templateType="$1"
+    echo "# User defined templates: $templateType" >> "${HOME}/.zshrc"
+    currentTemplateFiles=()
+    case $templateType in
+            "$TEMPLATE_START")
+                currentTemplateFiles=("${templates_start[@]}")
+                ;;
+            "$TEMPLATE_BETWEEN_ANTIGEN_AND_OH_MY_ZSH")
+                currentTemplateFiles=("${templates_between_antigen_and_oh_my_zsh[@]}")
+                ;;
+            "$TEMPLATE_BETWEEN_OH_MY_ZSH_AND_PLUGINS")
+                currentTemplateFiles=("${templates_between_oh_my_zsh_and_plugins[@]}")
+                ;;
+            "$TEMPLATE_AFTER_PLUGINS_BEFORE_ANTIGEN_APPLY")
+                currentTemplateFiles=("${templates_after_plugins_before_antigen_apply[@]}")
+                ;;
+            "$TEMPLATE_END")
+                currentTemplateFiles=("${templates_end[@]}")
+                ;;
+        esac
+    for templateFile in "${currentTemplateFiles[@]}"
+    do
+        currentTemplateFile="templates/${templateFile}"
+        echo "Applying template file ${templateFile}"
+        if tail -n +2 "$currentTemplateFile" >> "${HOME}/.zshrc"
+            then
+                print_success "Applied template file ${currentTemplateFile}!"
+            else
+                print_error "Failed to apply template file ${currentTemplateFile}!"
+                exit 1
+        fi
+    done
+}
+
+# Print warnings about template files that do not contain the #TEMPLATE=[TYPE]] header
+print_template_warnings() {
+    if [ "${#templates_invalid[@]}" -ge 1 ]
+        then
+            for templateFile in "${templates_invalid[@]}"
+            do
+                print_warning "Not applied template due to missing template directive: templates/${templateFile}!"
+            done
+    fi
+}


### PR DESCRIPTION
### Description
Improve performance of the template engine by reading every file less often than before. Also split the engine into an own script to keep things clean. Additionally a bug has been fixed where empty templates would throw an error.

### Issue
This PR addresses the following issues:
 - pascal-zarrad/psh #20 | Improve template performance

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
 - The template engine does its job faster (compare version before this commits to the current one).
 - The template engine still includes **all** templates at the right spot in the generated .zshrc.
 - When adding an empty template, the engine does no longer throw an error.
