### PR TITLE
Fix theme-loader on WSL2

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,6 +21,7 @@ But as the installer uses ```apt```, you need any system that supports ```apt```
 
 Currently psh is only tested in the following environments:
  * Ubuntu 18.04 (Windows Subsystem for Linux 1) (Take a look at "Note on WSL 1")
+ * Ubuntu 18.04 (Windows Subsystem for Linux 2)
  * Ubuntu 18.04
  * Debian 9
 

--- a/plugins/theme-loader/plugin.sh
+++ b/plugins/theme-loader/plugin.sh
@@ -11,8 +11,9 @@
 
 # As WSL can install powerline fonts, they need also be installed on windows itself.
 # So we just check if we're running on WSL and use another good font.
-if grep -q "Microsoft" "/proc/version"
+if grep -q "Microsoft" "/proc/version" || grep -q ".*microsoft-standard*." "/proc/version"
     then
+        echo "Running on Windows Subsystem for Linux, falling back to bira theme!"
         apply_antigen_theme "bira"
     else
         apply_antigen_theme "agnoster"


### PR DESCRIPTION
### Description
Fix the bug that WSL2 does not use the fallback theme.This lead to missing fonts in the shell that needed to be installed manually. (Same problem as WSL1)

### Issue
This PR addresses the following issues:
 - pascal-zarrad/psh #23 | Fix theme-loader on WSL 2

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
 - Run the installer on Ubuntu 18.04. Run `zsh`. ZSH should still use the agnoster theme.
 - Run the installer on Ubuntu 18.04 (WSL1). Run `zsh`. ZSH should use the bira theme as fallback.
 - Run the installer on Ubuntu 18.04 (WSL2). Run `zsh`. ZSH should use the bira theme as fallback.
