### PR TITLE
Execute apt update & upgrade on dependency installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,14 +100,17 @@ packages_installed() {
 install_apt_packages() {
     local use_sudo="$1"
     local package_install_command="$2"
+    IFS=' ' read -r -a package_install_arguments <<< "$package_install_command"
     echo "The installer has to install the following packages through apt (using sudo if available): "
+    echo "During package installation, an apt update & upgrade are done automatically!"
     echo -e "${COLOR_CYAN}${package_install_command}${COLOR_RESET}"
     yes_no_dialog "Do you want to continue? (y/n): "
+    echo "${package_install_arguments[@]}"
     if [ "$use_sudo" -eq 1 ]
         then
-            eval "sudo apt-get install -y $package_install_command"
+            sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y "${package_install_arguments[@]}"
         else
-            eval "apt-get install -y $package_install_command"
+            apt-get update && apt-get upgrade && apt-get install -y "${package_install_arguments[@]}"
     fi
     install_result="$?"
     if [ "$install_result" -ne 0 ]; then

--- a/lib/template_engine.sh
+++ b/lib/template_engine.sh
@@ -53,9 +53,9 @@ print_success "Completed template search!"
 
 # Include templates into the new .zshrc
 include_templates() {
-    templateType="$1"
+    local templateType="$1"
     echo "# User defined templates: $templateType" >> "${HOME}/.zshrc"
-    currentTemplateFiles=()
+    local currentTemplateFiles=()
     case $templateType in
             "$TEMPLATE_START")
                 currentTemplateFiles=("${templates_start[@]}")
@@ -75,7 +75,7 @@ include_templates() {
         esac
     for templateFile in "${currentTemplateFiles[@]}"
     do
-        currentTemplateFile="templates/${templateFile}"
+        local currentTemplateFile="templates/${templateFile}"
         echo "Applying template file ${templateFile}"
         if tail -n +2 "$currentTemplateFile" >> "${HOME}/.zshrc"
             then


### PR DESCRIPTION
### Description
Execute `apt update` and `apt upgrade` before installing all other dependencies. On systems that were just setup, the package information could be out of date.

### Issue
This PR addresses the following issues:
 - pascal-zarrad/psh #21| Run apt update & upgrade before install

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
 - Ensure that some dependency is not installed (Run to be sure that one is missing: `apt purge imagemagick`)
 - Run the installer
 - The console log shows that `apt update` and `apt upgrade` were run.