### PR TITLE
Only include files with proper extension

### DIFF
--- a/lib/template_engine.sh
+++ b/lib/template_engine.sh
@@ -21,7 +21,7 @@ templateFiles=()
 while IFS='' read -r line; do templateFiles+=("$line"); done < <(ls -1 templates)
 for templateFile in "${templateFiles[@]}"
 do
-    if [ -s "templates/$templateFile" ]; then
+    if [[ "$templateFile" =~ \.template.zshrc$ ]] && [ -s "templates/$templateFile" ]; then
         if read -r templateHeader < "templates/$templateFile"
             then
                 case $templateHeader in


### PR DESCRIPTION
### Description
Check for proper file extension on template files. This improves the security of psh a little bit.

### Issue
This PR addresses the following issues:
 - pascal-zarrad/psh #15  | Only include templates with proper file extension

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
 - Create a template with the wrong file extension
 - Run the install script
 - The template should not be included
