### PR TITLE
Add a write function to plugin api

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -195,23 +195,8 @@ if [ -f "${HOME}/.antigen/antigen.zsh" ]
         fi
 fi
 
-# Function that checks if antigen bundle is loaded or not
-# and then adds the bundle to the .zshrc
-apply_antigen_bundle() {
-    antigen_bundle="$1"
-    if ! grep -q "$antigen_bundle" "${HOME}/.zshrc" ; then
-        echo "antigen bundle ${antigen_bundle}" >> "${HOME}/.zshrc"
-    fi
-}
-
-# Function that checks if antigen theme is loaded or not
-# and then adds the theme to the .zshrc
-apply_antigen_theme() {
-    antigen_bundle="$1"
-    if ! grep -q "antigen theme ${antigen_bundle}" "${HOME}/.zshrc" ; then
-        echo "antigen theme ${antigen_bundle}" >> "${HOME}/.zshrc"
-    fi
-}
+# Load plugin API
+source "lib/plugin_api.sh"
 
 # First of all backup .zshrc
 echo ""

--- a/lib/plugin_api.sh
+++ b/lib/plugin_api.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#==================================================================
+# Script Name   : psh-plugin-api
+# Description	: Plugin API of psh. Provides usefull functions
+#                 for plugin development.
+# Args          : -
+# Author       	: Pascal Zarrad
+# Email         : P.Zarrad@outlook.de
+#==================================================================
+
+# Function that writes everything from the first parameter
+# to the .zshrc that is being generated
+write_zshrc() {
+    content="$1"
+    echo "$content" >> "${HOME}/.zshrc"
+}
+
+# Function that checks if antigen bundle is loaded or not
+# and then adds the bundle to the .zshrc
+apply_antigen_bundle() {
+    antigen_bundle="$1"
+    if ! grep -q "$antigen_bundle" "${HOME}/.zshrc" ; then
+        write_zshrc "antigen bundle ${antigen_bundle}"
+    fi
+}
+
+# Function that checks if antigen theme is loaded or not
+# and then adds the theme to the .zshrc
+apply_antigen_theme() {
+    antigen_bundle="$1"
+    if ! grep -q "antigen theme ${antigen_bundle}" "${HOME}/.zshrc" ; then
+        write_zshrc "antigen theme ${antigen_bundle}"
+    fi
+}


### PR DESCRIPTION
### Description
Add the `write_zshrc` function to the plugin api. Also put the plugin api in an own shellscript.

### Issue
This PR addresses the following issues:
 - pascal-zarrad/psh #22  | Implement custom plugin `write to zshrc` API

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
 - Create a plugin that writes something to the .zshrc using the `write_zshrc` function
 - Execute the installer
 - Everything from the past plugins is included in your .zshrc including your new addition to the .zshrc from your custom plugin.