### PR TITLE
Feature/prevent template inclusion

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,38 @@ readonly SUCCESS_PREFIX="${COLOR_GREEN}SUCCESS${COLOR_RESET}"
 readonly WARNING_PREFIX="${COLOR_YELLOW}WARNING${COLOR_RESET}"
 # ---- END: Constants used by PSH
 
+# Print help list
+cmd_help() {
+    echo "Usage of install.sh:"
+    echo "install.sh [--disable-templates] [--help]"
+    echo ""
+    echo "--help                - Prints this help page"
+    echo "--disable-templates   - Disables inclusion of templates"
+    echo ""
+    exit
+}
+
+# Our variables that are set by the start parameters
+start_arg_disable_template_engine=0
+# Process arguments/start parameters
+# and set values to use
+while test $# != 0
+do
+    case "$1" in
+        --disable-templates)
+            start_arg_disable_template_engine=1
+            ;;
+        --help)
+            cmd_help
+            ;;
+        *)
+            cmd_help
+            ;;
+    esac
+    shift
+done
+
+
 # Print an error message
 print_error() {
     echo -e "${ERROR_PREFIX} $1"

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ readonly SUCCESS_PREFIX="${COLOR_GREEN}SUCCESS${COLOR_RESET}"
 readonly WARNING_PREFIX="${COLOR_YELLOW}WARNING${COLOR_RESET}"
 # ---- END: Constants used by PSH
 
-# Print help list
+# Function to print usage of install.sh
 cmd_help() {
     echo "Usage of install.sh:"
     echo "install.sh [--disable-templates] [--help]"

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,6 @@ do
     shift
 done
 
-
 # Print an error message
 print_error() {
     echo -e "${ERROR_PREFIX} $1"

--- a/lib/template_engine.sh
+++ b/lib/template_engine.sh
@@ -53,6 +53,10 @@ print_success "Completed template search!"
 
 # Include templates into the new .zshrc
 include_templates() {
+    # $start_arg_disable_template_engine is set on install.sh
+    if [ "$start_arg_disable_template_engine" -eq 1 ]; then
+        return
+    fi
     local templateType="$1"
     echo "# User defined templates: $templateType" >> "${HOME}/.zshrc"
     local currentTemplateFiles=()
@@ -89,6 +93,10 @@ include_templates() {
 
 # Print warnings about template files that do not contain the #TEMPLATE=[TYPE]] header
 print_template_warnings() {
+    # $start_arg_disable_template_engine is set on install.sh
+    if [ "$start_arg_disable_template_engine" -eq 1 ]; then
+        return
+    fi
     if [ "${#templates_invalid[@]}" -ge 1 ]
         then
             for templateFile in "${templates_invalid[@]}"

--- a/lib/template_engine.sh
+++ b/lib/template_engine.sh
@@ -54,6 +54,7 @@ print_success "Completed template search!"
 # Include templates into the new .zshrc
 include_templates() {
     # $start_arg_disable_template_engine is set on install.sh
+    # shellcheck disable=SC2154
     if [ "$start_arg_disable_template_engine" -eq 1 ]; then
         return
     fi
@@ -94,6 +95,7 @@ include_templates() {
 # Print warnings about template files that do not contain the #TEMPLATE=[TYPE]] header
 print_template_warnings() {
     # $start_arg_disable_template_engine is set on install.sh
+    # shellcheck disable=SC2154
     if [ "$start_arg_disable_template_engine" -eq 1 ]; then
         return
     fi


### PR DESCRIPTION
### Description
Add a cli parameter/argument to disable template inclusion if wanted. Also add a help list for all available arguments

### Issue
This PR addresses the following issues:
 - pascal-zarrad/psh #17  | Add console parameter to prevent template inclusion

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
Test 1: 
- Execute install.sh
 - Check if all templates were included in .zshrc

Test 2:
- Run the installer the second time, but this time with `--disable-templates`
- Check if the content from all your templates are not included in the generated .zshrc

Test 3:
- Run `install.sh --help` (and in a second run of Test 3 with any other argumentthat does not exist)
-  The install script printd a list with all available arguments