### PR TITLE
Remove apt upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,9 +144,9 @@ install_apt_packages() {
     echo "${package_install_arguments[@]}"
     if [ "$use_sudo" -eq 1 ]
         then
-            sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y "${package_install_arguments[@]}"
+            sudo apt-get update && sudo apt-get install -y "${package_install_arguments[@]}"
         else
-            apt-get update && apt-get upgrade && apt-get install -y "${package_install_arguments[@]}"
+            apt-get update && apt-get install -y "${package_install_arguments[@]}"
     fi
     install_result="$?"
     if [ "$install_result" -ne 0 ]; then


### PR DESCRIPTION
### Description
It removes the `apt upgrade` on dependency installation.

### Issue
This PR addresses the following issues:
 - pascal-zarrad/psh #31  | Remove apt upgrade during dependency installation

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
 -  Ensure that a dependency is missing on your system (like xclip or imagemagick)
 - Run the installer
 - It should run `apt update` but not `apt upgrade` during dependency installation