### PR TITLE
Add option of unattended installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -370,7 +370,7 @@ echo "It is currently not configured as your default shell."
 echo -e "${COLOR_CYAN}NOTE${COLOR_RESET} Only set for your current user account!"
 if [ "$start_arg_run_unattended" -eq 0 ]
     then
-        read -r -p "Do you want to set zsh as your default shell? (y/n): "
+        read -r -p "Do you want to set zsh as your default shell? (y/n): " confirmDefaultShell
         if [ "$confirmDefaultShell" = "y" ] || [ "$confirmDefaultShell" = "yes" ];
             then
                change_shell_to_zsh


### PR DESCRIPTION
### Description
Implement the option of an unattended installation (An installation without any yes/no prompts) using the `--unattended` parameter.

### Issue
This PR addresses the following issues:
 - pascal-zarrad/psh #18 | Make unattended installation possible.

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
 - Run the installer the first time, without any arguments
 - The installer should display yes/no prompts during installation
 
- Run the installer the second time, but this time with `--unattended` as parameter

- Except password prompts, no yes/no dialogs should be shown during installation.