### PR TITLE
Add a gpg fix for WSL users

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ What is the expected behavior that is expected by the changes of the PR?
  - The installer does now x/y...
 
 ### Additional information
-Add here additional information if applicable or remove this section-
+Add here additional information if applicable or remove this section.
 
 #### Checklist
 Use the following checklist to ensure your PR meets all contribution requirements.

--- a/plugins/wsl-gpg/plugin.sh
+++ b/plugins/wsl-gpg/plugin.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#==================================================================
+# Script Name   : wsl-gpg
+# Description	: Plugin that puts a export into the .zshrc to use
+#                 the terminal for the gpg password prompt on wsl.
+# Args          : -
+# Author       	: Pascal Zarrad
+# Email         : P.Zarrad@outlook.de
+#==================================================================
+
+# This fix is only for WSL where gpg is unable to find a spot to prompt for
+# the password, so we add a environment variable to fix that.
+if grep -q "Microsoft" "/proc/version" || grep -q ".*microsoft-standard*." "/proc/version"
+    then
+        write_zshrc "export GPG_TTY=$(tty)"
+        echo "Applied wsl-gpg fix to support gpg on wsl!"
+fi


### PR DESCRIPTION
### Description
Added a feature that enables users on WSL1 & WSL2 to use gpg.
The behavior of gpg without the environment variable that is by the added plugin would end up in an error as gpg could not find a way to display the password prompt.

### Issue
This PR addresses the following issues:
 - #35 

### Test Scenarios
What is the expected behavior that is expected by the changes of the PR?
 - Execute psh on WSL. It should add `export GPG_TTY=$(tty)` to the `.zshrc`. GPG signing should work.
- Execute psh on Ubuntu/Debian. It should **not** add `export GPG_TTY=$(tty)` to the `.zshrc`.
