### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: 'CI'
+
+on: [push, pull_request]
+
+jobs:
+  shellcheck:
+    name: 'ShellCheck'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get install shellcheck
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        run: |
+          bash -c 'shopt -s globstar nullglob; shellcheck **/*.sh'
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Close stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3.0.5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue did not have any activity in the last 60 days. It has been marked as stale and will be closed soon.'
+        stale-pr-message: 'This pull request did not have any activity in the last 60 days. It has been marked as stale and will be closed soon.'
+        stale-issue-label: 'stale - no activity'
+        stale-pr-label: 'stale - no activity'
+        exempt-issue-labels: 'in progress'
+        exempt-pr-labels: 'in progress'
+        days-before-stale: 60
+        days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Close stale issues and pull requests
+name: 'Close stale issues and pull requests'
 
 on:
   schedule:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,3 +21,4 @@ jobs:
         exempt-pr-labels: 'in progress'
         days-before-stale: 60
         days-before-close: 7
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: shell
-os: [
-    "linux"
-]
-script:
- - bash -c 'shopt -s globstar nullglob; shellcheck **/*.sh'
-matrix:
-  fast_finish: true

--- a/lib/console.sh
+++ b/lib/console.sh
@@ -10,16 +10,16 @@
 #==================================================================
 
 # Colors used during script execution
-readonly COLOR_RESET="\e[0m"
-readonly COLOR_RED="\e[31m"
-readonly COLOR_GREEN="\e[32m"
-readonly COLOR_CYAN="\e[36m"
-readonly COLOR_YELLOW="\e[33m"
+export readonly COLOR_RESET="\e[0m"
+export readonly COLOR_RED="\e[31m"
+export readonly COLOR_GREEN="\e[32m"
+export readonly COLOR_CYAN="\e[36m"
+export  readonly COLOR_YELLOW="\e[33m"
 
 # Prefixes
-readonly ERROR_PREFIX="${COLOR_RED}ERROR${COLOR_RESET}"
-readonly SUCCESS_PREFIX="${COLOR_GREEN}SUCCESS${COLOR_RESET}"
-readonly WARNING_PREFIX="${COLOR_YELLOW}WARNING${COLOR_RESET}"
+export readonly ERROR_PREFIX="${COLOR_RED}ERROR${COLOR_RESET}"
+export readonly SUCCESS_PREFIX="${COLOR_GREEN}SUCCESS${COLOR_RESET}"
+export readonly WARNING_PREFIX="${COLOR_YELLOW}WARNING${COLOR_RESET}"
 
 # Print a message to the console
 #

--- a/lib/template_engine.sh
+++ b/lib/template_engine.sh
@@ -9,13 +9,13 @@
 #==================================================================
 
 # Template directive constant
-readonly TEMPLATE_DIRECTIVE="#PSH_TEMPLATE="
+export readonly TEMPLATE_DIRECTIVE="#PSH_TEMPLATE="
 # Different template insertion points
-readonly TEMPLATE_START="START"
-readonly TEMPLATE_BETWEEN_ANTIGEN_AND_OH_MY_ZSH="BETWEEN_ANTIGEN_AND_OH_MY_ZSH"
-readonly TEMPLATE_BETWEEN_OH_MY_ZSH_AND_PLUGINS="BETWEEN_OH_MY_ZSH_AND_PLUGINS"
-readonly TEMPLATE_AFTER_PLUGINS_BEFORE_ANTIGEN_APPLY="AFTER_PLUGINS_BEFORE_ANTIGEN_APPLY"
-readonly TEMPLATE_END="END"
+export readonly TEMPLATE_START="START"
+export readonly TEMPLATE_BETWEEN_ANTIGEN_AND_OH_MY_ZSH="BETWEEN_ANTIGEN_AND_OH_MY_ZSH"
+export readonly TEMPLATE_BETWEEN_OH_MY_ZSH_AND_PLUGINS="BETWEEN_OH_MY_ZSH_AND_PLUGINS"
+export readonly TEMPLATE_AFTER_PLUGINS_BEFORE_ANTIGEN_APPLY="AFTER_PLUGINS_BEFORE_ANTIGEN_APPLY"
+export readonly TEMPLATE_END="END"
 
 # Store the paths of our different template types in the arrays
 # to reduce I/O operations in comparison to v1 of the engine.


### PR DESCRIPTION
### Description
Use GitHub Actions to automate common task and move TravisCI to GitHub actions.

### Issue relations
Closes #39 

### Test Scenarios
All actions work as expected and the GitHub actions CI build runs the same as the old TravisCI one.
