### PR TITLE
Remove unnecessary shellcheck installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Install ShellCheck
-        run: |
-          sudo apt-get install shellcheck
       - name: Run ShellCheck
         run: |
           bash -c 'shopt -s globstar nullglob; shellcheck **/*.sh'


### PR DESCRIPTION
### Description
Remove the manuall ShellCheck installation on CI as GitHub already provides it preinstalled.

### Issue relations
Improves #39 

### Test Scenarios
Check if the build does no longer contain the "Install ShellCheck" step but still executes a check.
