### PR TITLE
Fix libraries on maOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@
 #==================================================================
 
 # Semantic versioning version constant
-readonly PSH_VERSION="2.2.0"
+readonly PSH_VERSION="2.2.1"
 echo "PSH - VERSION: ${PSH_VERSION}"
 
 if [ -f /etc/os-release ]; then

--- a/plugins/clipboard-enhancements/plugin.sh
+++ b/plugins/clipboard-enhancements/plugin.sh
@@ -24,6 +24,7 @@
 # Email         : P.Zarrad@outlook.de
 #==================================================================
 
+apply_ohmyzsh_lib "clipboard"
 apply_ohmyzsh_plugin "copypath"
 apply_ohmyzsh_plugin "copybuffer"
 apply_ohmyzsh_plugin "copyfile"

--- a/plugins/git/plugin.sh
+++ b/plugins/git/plugin.sh
@@ -24,6 +24,7 @@
 # Email         : P.Zarrad@outlook.de
 #==================================================================
 
+apply_ohmyzsh_lib "async_prompt"
 apply_ohmyzsh_plugin "git"
 apply_ohmyzsh_plugin "gitignore"
 apply_ohmyzsh_plugin "git-commit"

--- a/templates/load_ohmyzsh_lib.template.zshrc
+++ b/templates/load_ohmyzsh_lib.template.zshrc
@@ -1,6 +1,0 @@
-#PSH_TEMPLATE=BETWEEN_OH_MY_ZSH_AND_PLUGINS
-# With zplug we must load lib scripts ourselves.
-# Clipboard plugins or async git requires this.
-# This is included as template as it is basically needed
-# by multiple plugins.
-zplug "lib/*", from:oh-my-zsh


### PR DESCRIPTION
### Description
On macOS, the new version causes issues with the `omz_urlencode` function.
This PR only loads the really required libraries that are not loaded by the plugins/themes/zplug by default.